### PR TITLE
fix: correct kclrun ArgumentReferences property name comment

### DIFF
--- a/api/v1alpha1/kclrun_types.go
+++ b/api/v1alpha1/kclrun_types.go
@@ -121,7 +121,7 @@ type KCLRunSpec struct {
 	// +optional
 	Config *ConfigSpec `json:"config,omitempty" yaml:"config,omitempty"`
 
-	// ConfigReference holds references to ConfigMaps and Secrets containing
+	// ArgumentReferences holds references to ConfigMaps and Secrets containing
 	// the KCL compile config. The ConfigMap and the Secret data keys represent the config names.
 	// +optional
 	ArgumentsReferences []ArgumentReference `json:"argumentsReferences,omitempty" yaml:"argumentsReferences,omitempty"`


### PR DESCRIPTION
Fixes #128

Correct kclrun ArgumentReferences property name comment